### PR TITLE
Handle missing client IP gracefully

### DIFF
--- a/api/speedtest.php
+++ b/api/speedtest.php
@@ -186,10 +186,10 @@ try {
                 case 'cliente_info':
                     $cliente = $db->getClienteByIP($ipCliente);
                     if ($cliente) {
-                        echo json_encode(['success' => true, 'cliente' => $cliente]);
+                        echo json_encode(['success' => true, 'cliente' => $cliente, 'ip' => $ipCliente]);
                     } else {
                         http_response_code(404);
-                        echo json_encode(['error' => 'Cliente no encontrado']);
+                        echo json_encode(['error' => 'Cliente no encontrado', 'ip' => $ipCliente]);
                     }
                     break;
                     


### PR DESCRIPTION
## Summary
- Avoid sending placeholder IP values when client IP lookup fails
- Add local API fallback for client IP detection
- Expose server-detected IP via `cliente_info` endpoint

## Testing
- `php -l api/speedtest.php`


------
https://chatgpt.com/codex/tasks/task_e_6898b62512308329aa51cc95292e7861